### PR TITLE
replace forEach calls

### DIFF
--- a/src/randomMindustry/mappers/block/blocks/RandomItemTurret.java
+++ b/src/randomMindustry/mappers/block/blocks/RandomItemTurret.java
@@ -93,7 +93,7 @@ public class RandomItemTurret extends ItemTurret implements RandomBlock {
                 .crop(region.getX(), region.getY(), region.width, region.height), true);
         fullIcon = uiIcon = TextureManager.alloc(base);
 
-        ammoTypes.forEach(e -> e.value.load());
+        ammoTypes.each(e -> e.value.load());
     }
 
     private boolean pixmapLoaded = false;

--- a/src/randomMindustry/mappers/block/blocks/RandomItemTurret.java
+++ b/src/randomMindustry/mappers/block/blocks/RandomItemTurret.java
@@ -93,7 +93,7 @@ public class RandomItemTurret extends ItemTurret implements RandomBlock {
                 .crop(region.getX(), region.getY(), region.width, region.height), true);
         fullIcon = uiIcon = TextureManager.alloc(base);
 
-        ammoTypes.each(e -> e.value.load());
+        ammoTypes.each((k, v) -> v.load());
     }
 
     private boolean pixmapLoaded = false;

--- a/src/randomMindustry/texture/TextureManager.java
+++ b/src/randomMindustry/texture/TextureManager.java
@@ -33,7 +33,7 @@ public class TextureManager {
     }
 
     public static void reload() {
-        pages.each(e -> e.value.reload());
+        pages.each((k, v) -> v.reload());
     }
 
     public static Seq<Texture> getAllTextures() {

--- a/src/randomMindustry/texture/TextureManager.java
+++ b/src/randomMindustry/texture/TextureManager.java
@@ -33,7 +33,7 @@ public class TextureManager {
     }
 
     public static void reload() {
-        pages.forEach(e -> e.value.reload());
+        pages.each(e -> e.value.reload());
     }
 
     public static Seq<Texture> getAllTextures() {


### PR DESCRIPTION
`ObjectMap#forEach()`uses `java.util.Iterable`, which the Android ecosystem doesn't have. This causes content errors and crashes.

**`ObjectMap#each()` exists for a reason.**